### PR TITLE
fix: Bug sprint - resolve issues #7, #9, #10, #11, #12, #14

### DIFF
--- a/scripts/campaign.py
+++ b/scripts/campaign.py
@@ -230,7 +230,9 @@ def cmd_state_show(
             if chars:
                 print(f"\nCharacter states ({len(chars)}):")
                 for char_id, char_state in chars.items():
-                    print(f"  {char_id}: {len(char_state)} fields")
+                    count = len(char_state)
+                    word = "field" if count == 1 else "fields"
+                    print(f"  {char_id}: {count} {word}")
 
 
 def cmd_state_set(

--- a/scripts/characters.py
+++ b/scripts/characters.py
@@ -153,7 +153,8 @@ def format_value(value: Any, indent: int = 0) -> List[str]:
                 lines.append(f"{prefix}**{k}:**")
                 for item in v:
                     if isinstance(item, dict):
-                        lines.extend(format_value(item, indent + 1))
+                        lines.append(f"{prefix}  -")
+                        lines.extend(format_value(item, indent + 2))
                     else:
                         lines.append(f"{prefix}  - {item}")
             else:
@@ -161,7 +162,8 @@ def format_value(value: Any, indent: int = 0) -> List[str]:
     elif isinstance(value, list):
         for item in value:
             if isinstance(item, dict):
-                lines.extend(format_value(item, indent))
+                lines.append(f"{prefix}-")
+                lines.extend(format_value(item, indent + 1))
             else:
                 lines.append(f"{prefix}- {item}")
     else:

--- a/scripts/characters.py
+++ b/scripts/characters.py
@@ -139,6 +139,37 @@ def format_full(char: Dict) -> str:
     return "\n".join(lines)
 
 
+def format_value(value: Any, indent: int = 0) -> List[str]:
+    """Recursively format a value, handling nested dicts and lists."""
+    prefix = "  " * indent
+    lines = []
+
+    if isinstance(value, dict):
+        for k, v in value.items():
+            if isinstance(v, dict):
+                lines.append(f"{prefix}**{k}:**")
+                lines.extend(format_value(v, indent + 1))
+            elif isinstance(v, list):
+                lines.append(f"{prefix}**{k}:**")
+                for item in v:
+                    if isinstance(item, dict):
+                        lines.extend(format_value(item, indent + 1))
+                    else:
+                        lines.append(f"{prefix}  - {item}")
+            else:
+                lines.append(f"{prefix}**{k}:** {v}")
+    elif isinstance(value, list):
+        for item in value:
+            if isinstance(item, dict):
+                lines.extend(format_value(item, indent))
+            else:
+                lines.append(f"{prefix}- {item}")
+    else:
+        lines.append(f"{prefix}{value}")
+
+    return lines
+
+
 def format_section(char: Dict, section_name: str) -> str:
     """Format a specific section of a character."""
     name = char.get("name", char.get("id", "Unknown"))
@@ -156,9 +187,12 @@ def format_section(char: Dict, section_name: str) -> str:
                 lines.append(f"\n**{key}:**")
                 for item in value:
                     if isinstance(item, dict):
-                        lines.append(f"- {item}")
+                        lines.extend(format_value(item, 1))
                     else:
                         lines.append(f"- {item}")
+            elif isinstance(value, dict):
+                lines.append(f"\n**{key}:**")
+                lines.extend(format_value(value, 1))
             else:
                 lines.append(f"**{key}:** {value}")
     elif isinstance(section, list):

--- a/scripts/dice.py
+++ b/scripts/dice.py
@@ -28,7 +28,7 @@ class DiceRoll:
         """Parse the dice notation into components."""
         # Match dice sets like 2d6, 4d8kh3, etc.
         # Parse dice FIRST to avoid extracting modifiers from notation like 2d6+5d4
-        dice_pattern = r'(\d+)d(\d+|f)(?:(kh|kl|dh|dl|r|rr)(\d+)?)?(?:(!{1,2}p?)?)?(?:(>=|<=|>|<|=)(\d+)?)?'
+        dice_pattern = r'(\d*)d(\d+|f)(?:(kh|kl|dh|dl|r|rr)(\d+)?)?(?:(!{1,2}p?)?)?(?:(>=|<=|>|<|=)(\d+)?)?'
         dice_matches = re.findall(dice_pattern, self.notation)
 
         # Remove dice patterns from notation to find remaining static modifiers
@@ -44,7 +44,7 @@ class DiceRoll:
             raise ValueError(f"No valid dice notation found in '{self.original_notation}'")
 
         for match in dice_matches:
-            count = int(match[0])
+            count = int(match[0]) if match[0] else 1  # Default to 1 if omitted (e.g., "d6")
 
             # Handle Fudge/Fate dice specially
             if match[1].lower() == 'f':
@@ -334,6 +334,9 @@ def main():
 
     notation = sys.argv[1]
     dice_roll = DiceRoll(notation)
+    if dice_roll.error:
+        print(dice_roll.error)
+        sys.exit(1)
     dice_roll.roll()
     print(dice_roll.format_result())
 

--- a/scripts/log.py
+++ b/scripts/log.py
@@ -186,8 +186,8 @@ def cmd_add(
                     state = json.load(f)
                     if state.get("active_branch"):
                         entry["branch"] = state["active_branch"]
-            except (OSError, json.JSONDecodeError):
-                pass
+            except (OSError, json.JSONDecodeError) as e:
+                print(f"Warning: Could not auto-detect branch from state file: {e}", file=sys.stderr)
     if characters:
         entry["characters"] = parse_characters_arg(characters)
     if locations:


### PR DESCRIPTION
## Summary

Bug sprint fixing 6 issues in one focused session:

- **#7** Grammar: "1 fields" → "1 field" in campaign state show
- **#9** Auto-record active branch from `campaign/state.json` in log entries
- **#10** Exclude loose dates from date range queries in log list
- **#11** Fix nested dict display using recursive `format_value()` helper
- **#12** Exit code 1 on dice parse error + support `d6` shorthand for `1d6`
- **#14** Show orphaned locations with `[!parent 'X' not found]` warning in tree view

## Test plan

- [ ] `campaign.py state show` displays "1 field" for single-field characters
- [ ] `dice.py "invalid"` returns exit code 1
- [ ] `dice.py "d6"` rolls 1d6 successfully
- [ ] `log.py list --from Y1.D1 --to Y1.D5` excludes loose-date entries
- [ ] `characters.py get <char> --section <nested>` displays nested dicts properly
- [ ] `log.py add "test"` auto-records branch when `state.json` has `active_branch`
- [ ] `locations.py tree` shows orphaned locations with parent warning

Closes #7, #9, #10, #11, #12, #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)