### PR TITLE
feat(campaign): support comma-separated characters in state commands

### DIFF
--- a/references/campaign-state-guide.md
+++ b/references/campaign-state-guide.md
@@ -253,6 +253,11 @@ campaign.py state set juno location "market-district" \
   --reason "Arrived seeking information" \
   --session s05
 
+# Multiple characters at once (comma-separated)
+campaign.py state set kira,dex,tam location "threshold-station" \
+  --reason "Crew docked together" \
+  --session s02
+
 # Inventory
 campaign.py state set juno inventory.credits "450" \
   --reason "Paid Marco for intel"
@@ -267,6 +272,18 @@ Every state change is automatically logged to the changelog with:
 - Branch context
 - Old and new values
 - Reason for change
+
+### Delete Character State
+
+```bash
+# Remove a state field
+campaign.py state delete juno condition.wounded --reason "Healed at station"
+
+# Remove field from multiple characters at once
+campaign.py state delete kira,dex condition.wounded --reason "Party healed"
+```
+
+When deleting from multiple characters, the command continues on error and reports which characters failed (e.g., if a character doesn't have the field).
 
 ### State and Branches
 
@@ -601,6 +618,7 @@ characters.py list --branch ossian-arc
 - Always provide meaningful reasons for changelog
 - Use session identifiers consistently
 - Review state at session start to maintain continuity
+- Use comma-separated characters for party movement (e.g., `kira,dex,tam`)
 
 ### Character Development
 - Update character profiles when permanent changes occur

--- a/scripts/campaign.py
+++ b/scripts/campaign.py
@@ -251,8 +251,8 @@ def cmd_state_set(
     if "characters" not in campaign_state:
         campaign_state["characters"] = {}
 
-    # Split comma-separated characters
-    char_list = [c.strip() for c in characters.split(',')]
+    # Split comma-separated characters, filtering empty strings
+    char_list = [c.strip() for c in characters.split(',') if c.strip()]
     results = []
 
     changelog = load_changelog(Path.cwd())
@@ -283,14 +283,16 @@ def cmd_state_set(
             "change_id": entry.id
         })
 
-    save_state(Path.cwd(), campaign_state)
+    if results:
+        save_state(Path.cwd(), campaign_state)
 
     if output_json:
         print(json.dumps(results, indent=2))
     else:
         for r in results:
             print(f"Set {r['character']}.{r['field']} = {r['value']}")
-        print(f"Changes logged: {len(results)}")
+        if results:
+            print(f"Changes logged: {len(results)}")
 
 
 def cmd_state_delete(
@@ -307,8 +309,8 @@ def cmd_state_delete(
         print(f"Error: No state recorded for any character", file=sys.stderr)
         sys.exit(1)
 
-    # Split comma-separated characters
-    char_list = [c.strip() for c in characters.split(',')]
+    # Split comma-separated characters, filtering empty strings
+    char_list = [c.strip() for c in characters.split(',') if c.strip()]
     results = []
     errors = []
 


### PR DESCRIPTION
## Summary
- Add support for comma-separated character IDs in `state set` and `state delete` commands
- When multiple characters travel together, update all their locations in one command
- `state delete` continues on error and reports which characters failed

## Example Usage
```bash
# Update location for entire party
campaign.py state set kira,dex,tam location "threshold-station" --reason "Crew docked"

# Clear condition from multiple characters
campaign.py state delete kira,dex condition.wounded --reason "Party healed"
```

## Test plan
- [ ] Test `state set` with single character (existing behavior)
- [ ] Test `state set` with comma-separated characters
- [ ] Test `state delete` with single character (existing behavior)
- [ ] Test `state delete` with comma-separated characters
- [ ] Test `state delete` with mix of valid/invalid characters (should continue on error)
- [ ] Verify changelog has separate entries for each character
- [ ] Run `campaign.py --help` to verify updated examples

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)