### PR TITLE
docs(namegen): comprehensive documentation overhaul

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -82,10 +82,16 @@ These tools require JSON data files. See guides for schemas and examples.
 Requires `namesets/*.json`
 
 ```bash
-python scripts/namegen.py list                              # Show available namesets
-python scripts/namegen.py full --nameset ice-age-names      # Generate one name
-python scripts/namegen.py full --nameset NAME --count 5     # Multiple names
+python scripts/namegen.py list                                    # Show available namesets
+python scripts/namegen.py full --nameset NAME                     # Generate one name
+python scripts/namegen.py full --nameset NAME --count 5           # Generate multiple names
+python scripts/namegen.py full --nameset NAME --gender female     # Filter by gender
+python scripts/namegen.py full --nameset NAME --group western     # Force specific group/source
+python scripts/namegen.py full --nameset NAME --show-group        # Show which group was selected
+python scripts/namegen.py groups --nameset NAME                   # List groups/sources in nameset
 ```
+
+Options: `--nameset` (required), `--count`, `--gender`, `--group`, `--show-group`
 
 ### Characters
 

--- a/references/examples/namesets/aggregate-example.json
+++ b/references/examples/namesets/aggregate-example.json
@@ -1,0 +1,63 @@
+{
+  "id": "aggregate-example",
+  "name": "Metropolitan Station Crew",
+  "description": "Aggregate nameset demonstrating multi-source composition. References other namesets by ID and selects from them based on weight. Perfect for multicultural settings like space stations, international organizations, or cosmopolitan cities.",
+  "setting": "Sci-Fi / International",
+  "tags": ["aggregate", "multicultural", "example"],
+
+  "type": "aggregate",
+  "genderWeights": {"male": 50, "female": 50},
+  "format": "{firstName} {lastName}",
+
+  "sources": [
+    {
+      "nameset": "names-american",
+      "weight": 25,
+      "label": "american"
+    },
+    {
+      "nameset": "names-chinese",
+      "weight": 20,
+      "label": "chinese"
+    },
+    {
+      "nameset": "names-russian",
+      "weight": 15,
+      "label": "russian"
+    },
+    {
+      "nameset": "names-indian",
+      "weight": 15,
+      "label": "indian"
+    },
+    {
+      "nameset": "names-brazilian",
+      "weight": 10,
+      "label": "brazilian"
+    },
+    {
+      "nameset": "names-nigerian",
+      "weight": 10,
+      "label": "nigerian"
+    },
+    {
+      "nameset": "names-japanese",
+      "weight": 5,
+      "label": "japanese"
+    }
+  ],
+
+  "_notes": {
+    "usage": [
+      "Each source nameset must exist and have nameCategories with firstName and lastName",
+      "Weights are relative - total doesn't need to equal 100",
+      "Use --group japanese to force a specific source",
+      "Use --show-group to see which source was selected for each name"
+    ],
+    "example_commands": [
+      "python scripts/namegen.py full --nameset aggregate-example --count 10",
+      "python scripts/namegen.py full --nameset aggregate-example --group chinese --count 5",
+      "python scripts/namegen.py groups --nameset aggregate-example"
+    ]
+  }
+}

--- a/references/examples/namesets/custom-categories.json
+++ b/references/examples/namesets/custom-categories.json
@@ -1,0 +1,65 @@
+{
+  "id": "custom-categories-example",
+  "name": "Tribal Naming (Custom Categories)",
+  "description": "Demonstrates custom name categories for cultures without traditional surnames. Uses epithets (earned descriptors) and clan markers instead of family names. Suitable for prehistoric, tribal, or fantasy cultures.",
+  "setting": "Prehistoric / Tribal Fantasy",
+  "tags": ["tribal", "epithets", "custom-format", "example"],
+
+  "nameCategories": {
+    "firstName": [
+      {"name": "Keth", "gender": "male"},
+      {"name": "Thar", "gender": "male"},
+      {"name": "Brak", "gender": "male"},
+      {"name": "Vorn", "gender": "male"},
+      {"name": "Grenn", "gender": "male"},
+      {"name": "Sorh", "gender": "male"},
+      {"name": "Aella", "gender": "female"},
+      {"name": "Kela", "gender": "female"},
+      {"name": "Senna", "gender": "female"},
+      {"name": "Vorah", "gender": "female"},
+      {"name": "Brenna", "gender": "female"},
+      {"name": "Thela", "gender": "female"}
+    ],
+    "epithet": [
+      {"name": "the Swift", "frequency": 3},
+      {"name": "the Strong", "frequency": 3},
+      {"name": "Bear-Slayer", "frequency": 2},
+      {"name": "the Keen-Eyed", "frequency": 2},
+      {"name": "Flame-Keeper"},
+      {"name": "Storm-Bringer"},
+      {"name": "the Wise"},
+      {"name": "Bone-Carver"},
+      {"name": "the Scarred"},
+      {"name": "Ice-Walker"},
+      {"name": "Star-Reader"},
+      {"name": "the Silent"}
+    ],
+    "clan": [
+      {"name": "of the Elk-Hunters", "frequency": 4},
+      {"name": "of the Wolf-Pack", "frequency": 4},
+      {"name": "of the River-Folk", "frequency": 3},
+      {"name": "of the High-Passes", "frequency": 2},
+      {"name": "of the Steppe-Walkers", "frequency": 2},
+      {"name": "of the Frost-Line"},
+      {"name": "of the Bone-Keepers"},
+      {"name": "of the Star-Children"}
+    ]
+  },
+
+  "genderWeights": {"male": 50, "female": 50},
+  "format": "{firstName} {epithet}",
+
+  "_notes": {
+    "alternative_formats": {
+      "with_clan": "{firstName} {epithet} {clan}",
+      "formal": "{firstName} {clan}",
+      "simple": "{firstName}"
+    },
+    "design_notes": [
+      "Epithets are earned through deeds and can change over a character's life",
+      "Clan markers show band/tribe affiliation",
+      "Young or unnamed characters might use just firstName",
+      "Frequency weighting makes common epithets more likely"
+    ]
+  }
+}

--- a/references/examples/namesets/simple-western.json
+++ b/references/examples/namesets/simple-western.json
@@ -1,0 +1,49 @@
+{
+  "id": "simple-western-example",
+  "name": "Simple Western Names",
+  "description": "Basic Western naming structure with first and last names. Demonstrates gender tags and frequency weighting for realistic distribution.",
+  "setting": "Modern/Contemporary",
+  "tags": ["western", "modern", "example"],
+
+  "nameCategories": {
+    "firstName": [
+      {"name": "James", "gender": "male", "frequency": 5},
+      {"name": "John", "gender": "male", "frequency": 5},
+      {"name": "Robert", "gender": "male", "frequency": 4},
+      {"name": "Michael", "gender": "male", "frequency": 4},
+      {"name": "William", "gender": "male", "frequency": 3},
+      {"name": "David", "gender": "male", "frequency": 3},
+      {"name": "Thomas", "gender": "male", "frequency": 2},
+      {"name": "Marcus", "gender": "male"},
+      {"name": "Elena", "gender": "female", "frequency": 5},
+      {"name": "Maria", "gender": "female", "frequency": 5},
+      {"name": "Sofia", "gender": "female", "frequency": 4},
+      {"name": "Anna", "gender": "female", "frequency": 4},
+      {"name": "Sarah", "gender": "female", "frequency": 3},
+      {"name": "Emma", "gender": "female", "frequency": 3},
+      {"name": "Grace", "gender": "female", "frequency": 2},
+      {"name": "Vera", "gender": "female"},
+      {"name": "Alex", "gender": "unisex", "frequency": 3},
+      {"name": "Jordan", "gender": "unisex", "frequency": 2},
+      {"name": "Taylor", "gender": "unisex"},
+      {"name": "Morgan", "gender": "unisex"}
+    ],
+    "lastName": [
+      {"name": "Smith", "frequency": 5},
+      {"name": "Johnson", "frequency": 5},
+      {"name": "Williams", "frequency": 4},
+      {"name": "Brown", "frequency": 4},
+      {"name": "Jones", "frequency": 3},
+      {"name": "Garcia", "frequency": 3},
+      {"name": "Miller", "frequency": 2},
+      {"name": "Davis", "frequency": 2},
+      {"name": "Chen", "frequency": 2},
+      {"name": "Patel"},
+      {"name": "Kim"},
+      {"name": "Okonkwo"}
+    ]
+  },
+
+  "genderWeights": {"male": 50, "female": 50},
+  "format": "{firstName} {lastName}"
+}

--- a/references/nameset-guide.md
+++ b/references/nameset-guide.md
@@ -246,17 +246,17 @@ Aggregates compose from multiple source namesets, each with its own weight.
 
 ```bash
 # Force Japanese names only
-python scripts/namegen.py full --nameset station-crew --group japanese --count 5
+python scripts/namegen.py full --nameset station-personnel --group japanese --count 5
 
 # See which source was selected
-python scripts/namegen.py full --nameset station-crew --show-group
+python scripts/namegen.py full --nameset station-personnel --show-group
 # Output: Takeshi Yamamoto|japanese
 ```
 
 ### Listing Sources
 
 ```bash
-python scripts/namegen.py groups --nameset station-crew
+python scripts/namegen.py groups --nameset station-personnel
 # Shows each source with weight percentage and name counts
 ```
 

--- a/references/nameset-guide.md
+++ b/references/nameset-guide.md
@@ -1,49 +1,361 @@
 # Creating Namesets
 
-When a new culture, era, or group needs names, create a nameset JSON file.
+Namesets provide culturally-appropriate names for NPCs, places, or any entity needing generated names. The namegen tool supports three nameset types with flexible composition.
 
-## Default Structure
+## Quick Reference
 
-- 200 male first names
-- 200 female first names
-- 100 unisex first names
-- 200 last names
+```bash
+python scripts/namegen.py list                                    # List all namesets
+python scripts/namegen.py full --nameset NAME                     # Generate one name
+python scripts/namegen.py full --nameset NAME --count 5           # Generate multiple
+python scripts/namegen.py full --nameset NAME --gender female     # Filter by gender
+python scripts/namegen.py full --nameset NAME --group eastern     # Force specific group/source
+python scripts/namegen.py full --nameset NAME --show-group        # Show which group was selected
+python scripts/namegen.py groups --nameset NAME                   # List groups/sources in nameset
+```
 
-**However**, think critically about whether this fits the setting:
-- Prehistoric cultures may not have "last names" - use epithets or clan markers instead
-- Some cultures use patronymics rather than family names
-- Fantasy races might have completely different naming conventions
+---
 
-## Output Format
+## Nameset Types
 
-Save to `namesets/[theme-id].json`:
+### 1. Simple Nameset
+
+The most common type. Categories of names combined via format string.
 
 ```json
 {
-  "id": "theme-id",
-  "name": "Theme Display Name",
-  "description": "Explain the theme and any structural decisions",
-  "setting": "Campaign or setting name",
-  "tags": ["relevant", "tags"],
+  "id": "frontier-colonists",
+  "name": "Frontier Colonists",
+  "description": "Working-class names for frontier settlements",
+  "setting": "Space Western Campaign",
+  "tags": ["frontier", "working-class", "colonial"],
   "nameCategories": {
     "firstName": [
-      {"name": "Example", "gender": "male"},
-      {"name": "Example", "gender": "female"},
-      {"name": "Example", "gender": "unisex"}
+      {"name": "Jake", "gender": "male"},
+      {"name": "Rosa", "gender": "female"},
+      {"name": "River", "gender": "unisex"}
     ],
     "lastName": [
-      {"name": "Example"}
+      {"name": "Reyes"},
+      {"name": "Chen"},
+      {"name": "Okonkwo"}
     ]
   },
   "format": "{firstName} {lastName}"
 }
 ```
 
-Adjust `nameCategories` based on what makes sense (e.g., `epithet`, `clanName`, `parentage` instead of `lastName`).
+### 2. Aggregate Nameset
 
-## Guidelines
+Composes names from multiple source namesets with weighted selection. Perfect for multicultural settings.
 
-1. **Authenticity over fantasy**: Names should feel plausible for their cultural/historical context
-2. **Variety**: Diverse sounds, lengths, and styles within each category
-3. **Usability**: Pronounceable and memorable for RPG use
-4. **Think first**: Consider what naming conventions would actually exist in this culture
+```json
+{
+  "id": "station-personnel",
+  "name": "Station Personnel",
+  "description": "Multinational names for space station crew",
+  "type": "aggregate",
+  "genderWeights": {"male": 50, "female": 50},
+  "format": "{firstName} {lastName}",
+  "sources": [
+    {"nameset": "names-american", "weight": 30, "label": "american"},
+    {"nameset": "names-chinese", "weight": 25, "label": "chinese"},
+    {"nameset": "names-russian", "weight": 20, "label": "russian"},
+    {"nameset": "names-indian", "weight": 15, "label": "indian"},
+    {"nameset": "names-brazilian", "weight": 10, "label": "brazilian"}
+  ]
+}
+```
+
+Use `--group american` to force a specific source, or `--show-group` to see which was selected.
+
+### 3. Grouped Nameset
+
+Names organized into weighted groups within a single file. Useful when sources share structure but differ in style.
+
+```json
+{
+  "id": "fantasy-cultures",
+  "name": "Fantasy Cultures",
+  "description": "Names grouped by fictional culture",
+  "genderWeights": {"male": 50, "female": 50},
+  "format": "{firstName} {lastName}",
+  "nameGroups": {
+    "northern": {
+      "weight": 40,
+      "firstNames": [
+        {"name": "Bjorn", "gender": "male"},
+        {"name": "Freya", "gender": "female"}
+      ],
+      "lastNames": [
+        {"name": "Ironforge"},
+        {"name": "Stormborn"}
+      ]
+    },
+    "southern": {
+      "weight": 60,
+      "firstNames": [
+        {"name": "Marcus", "gender": "male"},
+        {"name": "Lucia", "gender": "female"}
+      ],
+      "lastNames": [
+        {"name": "Aurelius"},
+        {"name": "Varro"}
+      ]
+    }
+  }
+}
+```
+
+---
+
+## Schema Reference
+
+### Core Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `id` | Yes | Unique identifier (lowercase, hyphens) |
+| `name` | Yes | Display name |
+| `description` | No | Explains the nameset's purpose and style |
+| `setting` | No | Campaign or world this nameset belongs to |
+| `tags` | No | Array of searchable tags |
+| `format` | No | Format string (default: `"{firstName} {lastName}"`) |
+
+### Name Categories
+
+The `nameCategories` object holds arrays of name entries:
+
+```json
+"nameCategories": {
+  "firstName": [...],
+  "lastName": [...],
+  "epithet": [...],      // Custom category
+  "clanName": [...]      // Custom category
+}
+```
+
+Each entry in a category:
+
+```json
+{"name": "Marcus", "gender": "male", "frequency": 5}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | The actual name string |
+| `gender` | No | `"male"`, `"female"`, or `"unisex"`. Omit for gender-neutral. |
+| `frequency` | No | Relative weight (default: 1). Higher = more likely. |
+
+### Gender Weights
+
+Control the male/female distribution for the entire nameset:
+
+```json
+"genderWeights": {"male": 75, "female": 25}
+```
+
+Default is `{"male": 50, "female": 50}`. Can be overridden with `--gender male` or `--gender female`.
+
+### Frequency Weighting
+
+Make common names appear more often:
+
+```json
+"lastName": [
+  {"name": "Wang", "frequency": 10},
+  {"name": "Li", "frequency": 10},
+  {"name": "Zhang", "frequency": 9},
+  {"name": "Ouyang", "frequency": 1}
+]
+```
+
+Frequencies are relative weights, not percentages. A name with `frequency: 10` is 10x more likely than one with `frequency: 1`.
+
+---
+
+## Format Strings
+
+Format strings define how categories combine into full names.
+
+### Basic Placeholders
+
+```json
+"format": "{firstName} {lastName}"
+// Output: "Marcus Chen"
+```
+
+### Custom Categories
+
+Define any category name you need:
+
+```json
+"nameCategories": {
+  "firstName": [...],
+  "epithet": [
+    {"name": "the Swift"},
+    {"name": "Bear-Slayer"},
+    {"name": "One-Eye"}
+  ],
+  "clan": [
+    {"name": "of the River-Folk"},
+    {"name": "of the High-Passes"}
+  ]
+},
+"format": "{firstName} {epithet}"
+// Output: "Keth the Swift"
+```
+
+### Multiple Formats
+
+You can define alternative formats (the tool uses `format` by default):
+
+```json
+"format": "{firstName} {epithet}",
+"formatFormal": "{firstName} {epithet} {clan}",
+"formatShort": "{firstName}"
+```
+
+Note: Currently only `format` is used by the tool. Alternative formats serve as documentation for manual use.
+
+---
+
+## Aggregate Namesets
+
+Aggregates compose from multiple source namesets, each with its own weight.
+
+### Source Structure
+
+```json
+"sources": [
+  {
+    "nameset": "names-japanese",   // ID of source nameset (must exist)
+    "weight": 15,                  // Relative selection weight
+    "label": "japanese"            // Display label for --show-group
+  }
+]
+```
+
+### How It Works
+
+1. Tool selects a source based on weights
+2. Generates name from that source's `nameCategories`
+3. Uses aggregate's `format` and `genderWeights`
+
+### Forcing a Source
+
+```bash
+# Force Japanese names only
+python scripts/namegen.py full --nameset station-crew --group japanese --count 5
+
+# See which source was selected
+python scripts/namegen.py full --nameset station-crew --show-group
+# Output: Takeshi Yamamoto|japanese
+```
+
+### Listing Sources
+
+```bash
+python scripts/namegen.py groups --nameset station-crew
+# Shows each source with weight percentage and name counts
+```
+
+---
+
+## File Discovery
+
+Namesets are discovered from multiple locations (in order, later overrides earlier):
+
+1. `{cwd}/namesets/` - Current working directory
+2. `{parent}/namesets/` - Parent directories
+3. `campaigns/*/namesets/` - Campaign subdirectories
+4. `tools/data/namesets/` - Bundled default namesets
+5. `/mnt/user-data/uploads/namesets/` - Claude.ai uploads
+6. `/mnt/user-data/uploads/*-names.json` - Loose uploaded files
+7. `/home/claude/*/namesets/` - Extracted skill bundles
+
+### File Naming
+
+Two patterns work:
+
+- **Directory**: `namesets/my-culture.json`
+- **Loose files**: `my-culture-names.json` (must end in `-names.json`)
+
+---
+
+## Design Guidelines
+
+### 1. Think About Structure First
+
+Not all cultures use "first name + last name":
+
+| Culture Type | Structure | Example Format |
+|--------------|-----------|----------------|
+| Modern Western | Given + Family | `{firstName} {lastName}` |
+| East Asian | Family + Given | `{lastName} {firstName}` |
+| Patronymic | Given + Parent's name | `{firstName} {patronymic}` |
+| Epithet-based | Given + Descriptor | `{firstName} {epithet}` |
+| Single name | Given only | `{firstName}` |
+| Clan-based | Given + Clan marker | `{firstName} {clan}` |
+
+### 2. Consider Frequency Distribution
+
+Real name distributions follow power laws. Common names should have higher frequency:
+
+```json
+// Realistic Chinese surname distribution
+{"name": "Wang", "frequency": 10},  // ~7% of population
+{"name": "Li", "frequency": 10},    // ~7% of population
+{"name": "Ouyang", "frequency": 1}  // Rare compound surname
+```
+
+### 3. Default Counts (When Applicable)
+
+For simple Western-style namesets:
+- 200 male first names
+- 200 female first names
+- 100 unisex first names (optional)
+- 200 last names
+
+Adjust based on actual cultural patterns.
+
+### 4. Authenticity Over Fantasy
+
+Names should feel plausible for their context. Research actual naming conventions rather than inventing "fantasy-sounding" names.
+
+### 5. Usability
+
+Names should be:
+- Pronounceable by your players
+- Memorable enough to track NPCs
+- Distinct enough to avoid confusion
+
+---
+
+## Examples
+
+See `references/examples/namesets/` for complete working examples:
+
+- **simple-western.json** - Basic first/last name structure
+- **aggregate-metropolitan.json** - Multi-source composition
+- **custom-categories.json** - Non-Western naming patterns (epithets, clans)
+
+---
+
+## Legacy Format
+
+Older namesets may use `firstNames` and `lastNames` arrays directly:
+
+```json
+{
+  "id": "old-format",
+  "firstNames": [
+    {"name": "Jake", "gender": "male"}
+  ],
+  "lastNames": [
+    {"name": "Smith"}
+  ]
+}
+```
+
+This is automatically converted to `nameCategories` internally. New namesets should use `nameCategories`.


### PR DESCRIPTION
## Summary

- Rewrote `nameset-guide.md` from 50 lines to 362 lines with full feature coverage
- Updated SKILL.md namegen section with missing options (`--gender`, `--group`, `--show-group`, `groups` command)
- Created `references/examples/namesets/` with three working examples

## What's Now Documented

| Feature | Before | After |
|---------|--------|-------|
| Simple namesets | Partial | Full |
| Aggregate namesets | Missing | Full |
| Grouped namesets | Missing | Full |
| Frequency weighting | Missing | Full |
| Gender weights | Missing | Full |
| Custom categories | Missing | Full |
| Format string syntax | Basic | Full |
| Discovery paths | Missing | Full |
| Design guidelines | Basic | Expanded |

## Example Files

- `simple-western.json` - Basic first/last structure with frequency weighting
- `aggregate-example.json` - Multi-source composition pattern (template)
- `custom-categories.json` - Tribal naming with epithets and clan markers

## Test Plan

- [ ] Verify nameset-guide.md renders correctly
- [ ] Verify SKILL.md changes are accurate
- [ ] Review example JSON files for correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)