### PR TITLE
docs: Add table of contents to reference guides

### DIFF
--- a/references/campaign-state-guide.md
+++ b/references/campaign-state-guide.md
@@ -2,6 +2,26 @@
 
 Track campaign state across sessions with event logs, character state, branches for multi-protagonist campaigns, and a complete audit trail of all changes.
 
+## Contents
+
+- [System Overview](#system-overview)
+- [Campaign Initialization](#campaign-initialization)
+- [Export and Import](#export-and-import)
+- [Branch Management](#branch-management)
+- [Campaign Log](#campaign-log) — Adding, listing, viewing, deleting entries
+- [State Tracking](#state-tracking) — Volatile character state vs profile
+- [Character Development](#character-development) — Updating character profiles
+- [Changelog Queries](#changelog-queries) — Audit trail
+- [Calendar System](#calendar-system) — Offset and loose dates
+- [Campaign Digest](#campaign-digest) — Tiered overview
+- [Integration Patterns](#integration-patterns) — Session start/during/end workflows
+- [File Structure](#file-structure)
+- [Example Workflow: Multi-Branch Campaign](#example-workflow-multi-branch-campaign)
+- [Best Practices](#best-practices)
+- [Anti-Patterns](#anti-patterns---avoid-these)
+
+---
+
 ## System Overview
 
 The campaign state system provides:

--- a/references/character-guide.md
+++ b/references/character-guide.md
@@ -2,6 +2,17 @@
 
 Create character JSON files for the incremental character loading system. Files go in `characters/` folder and are loaded on-demand during sessions.
 
+## Contents
+
+- [JSON Schema](#json-schema)
+- [Workflow](#workflow) — Steps 1-6: gather, extract minimal, decide full, extract full, add sections, save
+- [Anti-Patterns](#anti-patterns---avoid-these)
+- [Example: Minimal-Only Character](#example-minimal-only-character)
+- [Faction Integration](#faction-integration)
+- [Example: Full Character](#example-full-character)
+
+---
+
 ## JSON Schema
 
 ```json

--- a/references/faction-guide.md
+++ b/references/faction-guide.md
@@ -2,6 +2,24 @@
 
 Create faction JSON files for tracking organizations with agency. Factions are treated as characters with structure, resources, and relationships. Files go in `factions/` folder.
 
+## Contents
+
+- [Design Philosophy](#design-philosophy)
+- [JSON Schema](#json-schema)
+- [Field Reference](#field-reference) — Required, recommended, minimal, full profile
+- [Hierarchy & Subfactions](#hierarchy--subfactions) — Parent, autonomy, siblings
+- [Relationship Edge Types](#relationship-edge-types) — ally, enemy, rival, debtor, etc.
+- [Member Tiers](#member-tiers) — Named, units, pools
+- [Economy Submodule](#economy-submodule) — Accounts, costs, inventory, assets
+- [Resources](#resources)
+- [Scale Examples](#scale-examples) — Crew, ship, vast organization
+- [Bidirectional Sync](#bidirectional-sync)
+- [Changelog Integration](#changelog-integration)
+- [Anti-Patterns](#anti-patterns---avoid-these)
+- [Workflow](#workflow) — Steps 1-7
+
+---
+
 ## Design Philosophy
 
 Factions are characters with agency. They have:

--- a/references/location-guide.md
+++ b/references/location-guide.md
@@ -2,6 +2,20 @@
 
 Create location JSON files for the hierarchical location loading system. Files go in `locations/` folder.
 
+## Contents
+
+- [JSON Schema](#json-schema)
+- [Hierarchy & Graph](#hierarchy--graph) — Tree (containment) and graph (travel) connections
+- [File Organization](#file-organization)
+- [Workflow](#workflow) — Steps 1-5: establish hierarchy, create roots, build down, add connections, full details
+- [Multi-Parent Locations](#multi-parent-locations)
+- [Tags](#tags)
+- [Faction Control](#faction-control)
+- [Anti-Patterns](#anti-patterns---avoid)
+- [Example: Grouped File](#example-grouped-file)
+
+---
+
 ## JSON Schema
 
 ```json

--- a/references/location-guide.md
+++ b/references/location-guide.md
@@ -11,7 +11,7 @@ Create location JSON files for the hierarchical location loading system. Files g
 - [Multi-Parent Locations](#multi-parent-locations)
 - [Tags](#tags)
 - [Faction Control](#faction-control)
-- [Anti-Patterns](#anti-patterns---avoid)
+- [Anti-Patterns](#anti-patterns---avoid-these)
 - [Example: Grouped File](#example-grouped-file)
 
 ---
@@ -205,7 +205,7 @@ For military installations, ships, or faction headquarters, the faction relation
 
 See [Creating Factions](faction-guide.md) for faction schema and territory tracking.
 
-## Anti-Patterns - AVOID
+## Anti-Patterns - AVOID These
 
 - Exhaustive history for minor locations - evocative > exhaustive
 - Missing parent references - breaks tree view

--- a/references/memories-guide.md
+++ b/references/memories-guide.md
@@ -2,6 +2,19 @@
 
 Create memory JSON files for campaign memory tracking. Files go in `memories/` folder and support cross-references to characters, locations, and other memories.
 
+## Contents
+
+- [JSON Schema](#json-schema)
+- [Field Reference](#field-reference) — Required, recommended, optional metadata, connections
+- [CLI Reference](#cli-reference)
+- [Workflow](#workflow) — Steps 1-5: capture, write, categorize, connect, save
+- [Example: Vivid Moment](#example-vivid-moment)
+- [Example: Quiet Moment](#example-quiet-moment)
+- [Example: World-Building](#example-world-building)
+- [Using Memories in Sessions](#using-memories-in-sessions)
+
+---
+
 ## JSON Schema
 
 ```json

--- a/references/nameset-guide.md
+++ b/references/nameset-guide.md
@@ -2,6 +2,20 @@
 
 Namesets provide culturally-appropriate names for NPCs, places, or any entity needing generated names. The namegen tool supports three nameset types with flexible composition.
 
+## Contents
+
+- [Quick Reference](#quick-reference)
+- [Nameset Types](#nameset-types) — Simple, Aggregate, Grouped
+- [Schema Reference](#schema-reference) — Core fields, name categories, gender weights, frequency
+- [Format Strings](#format-strings)
+- [Aggregate Namesets](#aggregate-namesets)
+- [File Discovery](#file-discovery)
+- [Design Guidelines](#design-guidelines)
+- [Examples](#examples)
+- [Legacy Format](#legacy-format)
+
+---
+
 ## Quick Reference
 
 ```bash

--- a/references/oracle-guide.md
+++ b/references/oracle-guide.md
@@ -4,6 +4,16 @@ The oracle tool provides randomness to stimulate interpretation. It gives you ra
 
 There are no predefined meanings. A rune doesn't "mean" one thing. A hexagram doesn't dictate an outcome. The oracle provides friction, surprise, and direction. The narrative intelligence does the rest.
 
+## Contents
+
+- [When to Consult the Oracle](#when-to-consult-the-oracle)
+- [Oracle Types](#oracle-types) — Axis, Omni, Tarot, Runes, I Ching, Fate, Prompt
+- [Working with Oracle Output](#working-with-oracle-output)
+- [Combining Systems](#combining-systems)
+- [Philosophy](#philosophy)
+
+---
+
 ## When to Consult the Oracle
 
 Use the oracle when you need:


### PR DESCRIPTION
## Summary

- Add TOC to 7 reference files that exceed 100 lines, per skill-creator guidelines
- TOCs help Claude see full scope when previewing reference files

Files updated:
- oracle-guide.md (140 lines)
- character-guide.md (204 lines)
- location-guide.md (235 lines)
- memories-guide.md (250 lines)
- nameset-guide.md (361 lines)
- campaign-state-guide.md (664 lines)
- faction-guide.md (826 lines)

## Test plan

- [ ] Verify TOC links work in GitHub preview
- [ ] Verify markdown renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)