### PR TITLE
feat(namegen): flexible gender system and format enhancements

### DIFF
--- a/docs/plans/2026-01-24-namegen-enhancements.md
+++ b/docs/plans/2026-01-24-namegen-enhancements.md
@@ -1,0 +1,277 @@
+# Namegen Tool Enhancements Plan
+
+**Date:** 2026-01-24
+**Feature:** Enhanced name generation with flexible gender system and format string improvements
+**Branch:** `feature/namegen-enhancements`
+
+## Overview
+
+Overhaul the namegen tool to support complex fantasy naming conventions. Fixes aggregate namesets with custom categories (#62), implements proper gender cascading across all categories (#63), adds optional sections with weights, and introduces random pattern generation for constructs/designations.
+
+## Design Summary
+
+**Key Changes:**
+1. Gender cascades to ALL categories, not just firstName
+2. Per-placeholder gender override: `{category:male}`
+3. Optional sections: `[ {epithet}]` and `[ {epithet}:30%]`
+4. Random generation: `{random:1-99}` (range) and `{random:AAA}` (pattern)
+5. Arbitrary gender support via genderWeights
+
+---
+
+## Batch 1: Bugfix - Aggregate Custom Categories (#62)
+
+### Task 1.1: Create feature branch
+```bash
+git checkout -b feature/namegen-enhancements develop
+```
+
+### Task 1.2: Fix `generate_single_name()` to use source categories
+Current code hardcodes `firstName`/`lastName` lookup. Fix to:
+- Use source nameset's actual `nameCategories`
+- Use source nameset's `format` string (not aggregate's)
+- Pass through all categories, not just firstName/lastName
+
+### Task 1.3: Fix `generate_from_aggregate()` delegation
+- After selecting a source, delegate fully to source's format and categories
+- Remove hardcoded category assumptions
+- Let source nameset handle its own structure
+
+### Task 1.4: Test aggregate with custom categories
+- Create test case with lizardfolk nameset (clutchSyllable, selfSyllable)
+- Verify aggregate produces actual names, not empty strings
+- Verify no "undefined category" warnings
+
+---
+
+## Batch 2: Gender Cascade System (#63)
+
+### Task 2.1: Modify `build_name_from_format()` to accept gender
+Add `gender: Optional[str] = None` parameter.
+- Thread gender through from generation entry points
+- Apply to each category during name building
+
+### Task 2.2: Apply gender filter to ALL categories
+In `build_name_from_format()`:
+- Before selecting from any category, apply `filter_by_gender(entries, gender)`
+- Not just firstName - all categories with gender-tagged entries
+
+### Task 2.3: Add warning for empty filtered categories
+When `filter_by_gender()` returns empty and falls back:
+```python
+if not filtered:
+    print(f"Warning: {category} has no entries for gender '{gender}', using unfiltered", file=sys.stderr)
+    return entries
+```
+
+### Task 2.4: Thread gender through all generation paths
+Update these functions to pass gender to `build_name_from_format()`:
+- `generate_from_nameset()`
+- `generate_from_nameset_with_groups()`
+- `generate_from_aggregate()` / `generate_single_name()`
+
+---
+
+## Batch 3: Per-Placeholder Gender Override
+
+### Task 3.1: Extend format parser for gender syntax
+Update `parse_format()` to recognize `{category:gender}`:
+```python
+# Pattern: {category} or {category:gender}
+pattern = r'\{(\w+)(?::(\w+))?\}'
+```
+Token becomes: `{"type": "placeholder", "category": "firstName", "gender": "male"}`
+
+### Task 3.2: Apply per-placeholder gender in `build_name_from_format()`
+When building name:
+- If placeholder has explicit gender → use that
+- Else → use character's gender (passed in)
+- Filter category accordingly
+
+### Task 3.3: Update nameset-guide.md with gender override syntax
+Document:
+```json
+"format": "{firstName} {firstName:male}{suffix} {firstName:female}{suffix}"
+```
+Explain: `:gender` overrides character gender for that placeholder only.
+
+---
+
+## Batch 4: Arbitrary Genders
+
+### Task 4.1: Remove hardcoded male/female assumptions
+In `select_gender()` and `filter_by_gender()`:
+- Work with whatever genders are defined in `genderWeights`
+- No hardcoded defaults beyond `{"male": 50, "female": 50}`
+
+### Task 4.2: Update `filter_by_gender()` for arbitrary genders
+Rules:
+- `unisex` entries match ANY gender
+- Untagged entries (gender: null) match ANY gender
+- Explicit gender tags require exact match
+- Works for `neuter`, `construct`, or any custom gender
+
+### Task 4.3: Document arbitrary genders in nameset-guide.md
+```json
+"genderWeights": {"male": 40, "female": 40, "neuter": 20}
+```
+Entries can use any gender tag that appears in genderWeights.
+
+---
+
+## Batch 5: Optional Sections
+
+### Task 5.1: Implement optional section parsing
+Update `parse_format()` to properly handle `[content]`:
+- Already parses but treated as literal
+- Mark as `{"type": "optional", "content": parsed_inner_tokens, "weight": 100}`
+
+### Task 5.2: Implement weighted optional syntax
+Parse `[ {category}:30%]`:
+- Extract weight percentage
+- Store as `{"type": "optional", "content": [...], "weight": 30}`
+
+### Task 5.3: Implement optional section logic in `build_name_from_format()`
+For optional tokens:
+- Roll against weight percentage (default 100%)
+- If roll succeeds AND inner categories have entries → include
+- If category empty → skip section (no warning, graceful degradation)
+- Clean up whitespace (avoid double spaces)
+
+### Task 5.4: Document optional sections
+```json
+"format": "{firstName}[ {epithet}] {lastName}"        // include if exists
+"format": "{firstName}[ {epithet}:30%] {lastName}"   // 30% chance
+```
+
+---
+
+## Batch 6: Random Pattern Generation
+
+### Task 6.1: Add `{random:...}` placeholder parsing
+In `parse_format()`, detect `{random:pattern}`:
+- Token: `{"type": "random", "pattern": "AAA"}` or `{"type": "random", "range": [1, 99]}`
+
+### Task 6.2: Implement range detection
+Detect `N-M` where both are integers with single dash:
+- `1-99` → range
+- `0-255` → range
+- `000` → pattern (no dash)
+- `A-Z` → pattern (non-integer)
+
+### Task 6.3: Implement pattern generation
+Pattern characters:
+- `A` → random uppercase letter (A-Z)
+- `a` → random lowercase letter (a-z)
+- `0` → random digit (0-9)
+- `X` → random hex digit (0-9, A-F)
+- Anything else → literal
+
+```python
+def generate_pattern(pattern: str) -> str:
+    result = []
+    for char in pattern:
+        if char == 'A':
+            result.append(random.choice('ABCDEFGHIJKLMNOPQRSTUVWXYZ'))
+        elif char == 'a':
+            result.append(random.choice('abcdefghijklmnopqrstuvwxyz'))
+        elif char == '0':
+            result.append(random.choice('0123456789'))
+        elif char == 'X':
+            result.append(random.choice('0123456789ABCDEF'))
+        else:
+            result.append(char)
+    return ''.join(result)
+```
+
+### Task 6.4: Implement range generation
+```python
+def generate_range(min_val: int, max_val: int) -> str:
+    return str(random.randint(min_val, max_val))
+```
+
+### Task 6.5: Document random generation
+Ranges:
+```json
+"{random:1-99}"      // 1 to 99
+"{random:0-255}"     // 0 to 255
+```
+
+Patterns:
+```json
+"{random:AAA}"       // 3 uppercase letters → "KXR"
+"{random:000}"       // 3 zero-padded digits → "042"
+"{random:XXX}"       // 3 hex digits → "A7F"
+```
+
+Composed patterns (for mixed):
+```json
+"{random:AA}-{random:0000}"   // "KX-0742"
+```
+
+---
+
+## Batch 7: Documentation & Testing
+
+### Task 7.1: Update nameset-guide.md comprehensively
+- Gender cascade explanation
+- Per-placeholder override syntax
+- Arbitrary genders
+- Optional sections with weights
+- Random generation (ranges and patterns)
+- Examples for each feature
+
+### Task 7.2: Add example namesets demonstrating new features
+Create `references/examples/namesets/`:
+- `dwarven-patronymic.json` - gender-filtered patronyms/matronyms
+- `construct-designations.json` - random patterns for robots/constructs
+- `fantasy-epithets.json` - optional epithets with weights
+
+### Task 7.3: Manual testing
+- Dwarf names with patronymic/matronymic suffixes
+- Aggregate with custom categories (lizardfolk/korvathi)
+- Construct designations (CT-0000 style)
+- Optional epithets at 30% rate
+- Non-binary gender filtering
+
+### Task 7.4: Create PR
+- Reference issues #62 and #63
+- Summary of all new features
+- Test plan with example outputs
+- "Closes #62, Closes #63" in body
+
+---
+
+## Format String Grammar (Final)
+
+```
+format      = token*
+token       = placeholder | optional | random | literal
+placeholder = "{" category (":" gender)? "}"
+optional    = "[" token* (":" weight "%")? "]"
+random      = "{random:" (range | pattern) "}"
+range       = integer "-" integer
+pattern     = (A | a | 0 | X | literal_char)+
+literal     = any_char_except_brackets
+```
+
+**Examples:**
+```
+{firstName}                    // character's gender
+{firstName:male}               // force male
+[ {epithet}]                   // optional, include if exists
+[ {epithet}:30%]               // optional, 30% chance
+{random:1-99}                  // range 1-99
+{random:AAA}                   // 3 uppercase letters
+{random:AA}-{random:0000}      // composed: "KX-0742"
+```
+
+---
+
+## Notes
+
+- All changes are backwards-compatible (existing namesets work unchanged)
+- Gender cascade is automatic - no schema changes required
+- Optional sections gracefully degrade when categories are empty
+- Random generation is self-contained (no external dependencies)
+- Pattern vs range detection uses simple heuristic (single dash with integers on both sides = range)

--- a/references/examples/namesets/construct-designations.json
+++ b/references/examples/namesets/construct-designations.json
@@ -1,0 +1,67 @@
+{
+  "id": "construct-designations-example",
+  "name": "Construct Designations",
+  "description": "Demonstrates random generation patterns for robots, constructs, and procedural naming. Shows numeric ranges {random:1-999}, letter patterns {random:AAA}, digit patterns {random:0000}, and hex patterns {random:XXXX}.",
+  "setting": "Sci-Fi / Cyberpunk",
+  "tags": ["construct", "robot", "random-patterns", "procedural", "example"],
+
+  "nameCategories": {
+    "prefix": [
+      {"name": "MK", "frequency": 3},
+      {"name": "XR", "frequency": 2},
+      {"name": "Unit", "frequency": 3},
+      {"name": "Model", "frequency": 2},
+      {"name": "Series"},
+      {"name": "Type"},
+      {"name": "Proto"},
+      {"name": "Gen"}
+    ],
+    "class": [
+      {"name": "Alpha", "gender": "military", "frequency": 2},
+      {"name": "Bravo", "gender": "military"},
+      {"name": "Charlie", "gender": "military"},
+      {"name": "Delta", "gender": "military"},
+      {"name": "Omicron", "gender": "civilian", "frequency": 2},
+      {"name": "Sigma", "gender": "civilian"},
+      {"name": "Lambda", "gender": "civilian"},
+      {"name": "Omega", "gender": "prototype"}
+    ],
+    "role": [
+      {"name": "Combat", "gender": "military"},
+      {"name": "Assault", "gender": "military"},
+      {"name": "Defense", "gender": "military"},
+      {"name": "Service", "gender": "civilian", "frequency": 3},
+      {"name": "Medical", "gender": "civilian", "frequency": 2},
+      {"name": "Domestic", "gender": "civilian"},
+      {"name": "Research", "gender": "prototype"},
+      {"name": "Experimental", "gender": "prototype"}
+    ]
+  },
+
+  "genderWeights": {"military": 40, "civilian": 50, "prototype": 10},
+  "format": "{prefix}-{random:0000}",
+
+  "_notes": {
+    "feature_demonstrated": "Random generation with {random:pattern} syntax",
+    "pattern_characters": {
+      "A": "Random uppercase letter (A-Z)",
+      "a": "Random lowercase letter (a-z)",
+      "0": "Random digit (0-9)",
+      "X": "Random hex digit (0-9, A-F)",
+      "other": "Literal character (preserved)"
+    },
+    "alternative_formats": {
+      "letter_prefix": "{random:AAA}-{random:000}",
+      "hex_id": "{prefix}-0x{random:XXXX}",
+      "with_class": "{class}-{random:00}",
+      "full_designation": "{role} {class} {prefix}-{random:0000}",
+      "serial_range": "{prefix}-{random:1-9999}"
+    },
+    "arbitrary_genders_note": "This example uses 'military', 'civilian', and 'prototype' as gender categories to demonstrate that any string can be used for categorical filtering, not just male/female.",
+    "usage": [
+      "python scripts/namegen.py full --nameset construct-designations-example --count 5",
+      "python scripts/namegen.py full --nameset construct-designations-example --gender military",
+      "python scripts/namegen.py full --nameset construct-designations-example --gender prototype"
+    ]
+  }
+}

--- a/references/examples/namesets/dwarven-patronymic.json
+++ b/references/examples/namesets/dwarven-patronymic.json
@@ -1,0 +1,69 @@
+{
+  "id": "dwarven-patronymic-example",
+  "name": "Dwarven Patronymic Names",
+  "description": "Demonstrates per-placeholder gender override for patronymic naming. Each dwarf has their own name plus their father's name with -sson and mother's name with -sdottir. Uses {firstName:male} and {firstName:female} to select parent names independent of the child's gender.",
+  "setting": "Fantasy / Norse-inspired",
+  "tags": ["dwarven", "patronymic", "gender-override", "example"],
+
+  "nameCategories": {
+    "firstName": [
+      {"name": "Thorin", "gender": "male", "frequency": 3},
+      {"name": "Balin", "gender": "male", "frequency": 3},
+      {"name": "Dwalin", "gender": "male", "frequency": 2},
+      {"name": "Gimli", "gender": "male", "frequency": 3},
+      {"name": "Gloin", "gender": "male", "frequency": 2},
+      {"name": "Oin", "gender": "male"},
+      {"name": "Bifur", "gender": "male"},
+      {"name": "Bofur", "gender": "male"},
+      {"name": "Bombur", "gender": "male"},
+      {"name": "Fili", "gender": "male"},
+      {"name": "Kili", "gender": "male"},
+      {"name": "Nori", "gender": "male"},
+      {"name": "Dori", "gender": "male"},
+      {"name": "Ori", "gender": "male"},
+      {"name": "Thrain", "gender": "male"},
+      {"name": "Thror", "gender": "male"},
+      {"name": "Dis", "gender": "female", "frequency": 3},
+      {"name": "Hild", "gender": "female", "frequency": 3},
+      {"name": "Freya", "gender": "female", "frequency": 2},
+      {"name": "Sigrid", "gender": "female", "frequency": 2},
+      {"name": "Brunhild", "gender": "female"},
+      {"name": "Astrid", "gender": "female"},
+      {"name": "Helga", "gender": "female"},
+      {"name": "Ingrid", "gender": "female"},
+      {"name": "Thyra", "gender": "female"},
+      {"name": "Gudrun", "gender": "female"},
+      {"name": "Eira", "gender": "female"},
+      {"name": "Runa", "gender": "female"}
+    ],
+    "clan": [
+      {"name": "Ironforge", "frequency": 3},
+      {"name": "Stonehelm", "frequency": 3},
+      {"name": "Deepdelve", "frequency": 2},
+      {"name": "Goldbeard", "frequency": 2},
+      {"name": "Firebeard"},
+      {"name": "Broadbeam"},
+      {"name": "Blacklock"},
+      {"name": "Stiffbeard"}
+    ]
+  },
+
+  "genderWeights": {"male": 60, "female": 40},
+  "format": "{firstName} {firstName:male}sson {firstName:female}sdottir",
+
+  "_notes": {
+    "feature_demonstrated": "Per-placeholder gender override with {category:gender} syntax",
+    "how_it_works": [
+      "The child's firstName uses the global gender (rolled or --gender flag)",
+      "{firstName:male} ALWAYS selects from male names regardless of child's gender",
+      "{firstName:female} ALWAYS selects from female names regardless of child's gender",
+      "Result: 'Dis Thorinsson Hildsdottir' (female child of Thorin and Hild)"
+    ],
+    "alternative_formats": {
+      "father_only": "{firstName} {firstName:male}sson",
+      "mother_only": "{firstName} {firstName:female}sdottir",
+      "with_clan": "{firstName} {firstName:male}sson of Clan {clan}"
+    },
+    "usage": "python scripts/namegen.py full --nameset dwarven-patronymic-example --count 5"
+  }
+}

--- a/references/examples/namesets/fantasy-epithets.json
+++ b/references/examples/namesets/fantasy-epithets.json
@@ -1,0 +1,82 @@
+{
+  "id": "fantasy-epithets-example",
+  "name": "Fantasy Names with Optional Epithets",
+  "description": "Demonstrates optional sections with probability weights. Uses [ {epithet}:30%] syntax to give characters a 30% chance of having an earned title. The optional section only appears when the probability roll succeeds.",
+  "setting": "Fantasy",
+  "tags": ["fantasy", "epithets", "optional-sections", "probability", "example"],
+
+  "nameCategories": {
+    "firstName": [
+      {"name": "Aldric", "gender": "male", "frequency": 2},
+      {"name": "Cedric", "gender": "male", "frequency": 2},
+      {"name": "Edmund", "gender": "male"},
+      {"name": "Gareth", "gender": "male"},
+      {"name": "Roland", "gender": "male"},
+      {"name": "Tristan", "gender": "male"},
+      {"name": "Varen", "gender": "male"},
+      {"name": "Wulfric", "gender": "male"},
+      {"name": "Aelindra", "gender": "female", "frequency": 2},
+      {"name": "Brianna", "gender": "female", "frequency": 2},
+      {"name": "Cordelia", "gender": "female"},
+      {"name": "Elara", "gender": "female"},
+      {"name": "Gwendolyn", "gender": "female"},
+      {"name": "Isolde", "gender": "female"},
+      {"name": "Lysandra", "gender": "female"},
+      {"name": "Rowena", "gender": "female"}
+    ],
+    "epithet": [
+      {"name": "the Bold", "frequency": 3},
+      {"name": "the Wise", "frequency": 3},
+      {"name": "the Just", "frequency": 2},
+      {"name": "the Brave", "frequency": 2},
+      {"name": "Dragonslayer"},
+      {"name": "Shadowbane"},
+      {"name": "Ironhand"},
+      {"name": "the Wanderer"},
+      {"name": "Stormcaller"},
+      {"name": "the Healer"},
+      {"name": "Truthseeker"},
+      {"name": "the Scarred"}
+    ],
+    "lastName": [
+      {"name": "Ashford", "frequency": 2},
+      {"name": "Blackwood", "frequency": 2},
+      {"name": "Coldwell"},
+      {"name": "Dunmore"},
+      {"name": "Fairfax"},
+      {"name": "Goldleaf"},
+      {"name": "Highmore"},
+      {"name": "Ironwood"},
+      {"name": "Kingsley"},
+      {"name": "Ravencrest"}
+    ]
+  },
+
+  "genderWeights": {"male": 50, "female": 50},
+  "format": "{firstName}[ {epithet}:30%] {lastName}",
+
+  "_notes": {
+    "feature_demonstrated": "Optional sections with probability weights using [ content:N%] syntax",
+    "how_it_works": [
+      "[ {epithet}:30%] wraps the epithet in an optional section",
+      "30% of generated names will include an epithet",
+      "70% will just be '{firstName} {lastName}'",
+      "Without a weight ([ {epithet}]), inclusion is 100% when content exists"
+    ],
+    "alternative_formats": {
+      "always_epithet": "{firstName} {epithet} {lastName}",
+      "optional_epithet_50": "{firstName}[ {epithet}:50%] {lastName}",
+      "optional_epithet_always": "{firstName}[ {epithet}] {lastName}",
+      "optional_both": "{firstName}[ {epithet}:30%][ of House {lastName}:70%]"
+    },
+    "design_notes": [
+      "Epithets represent earned titles - not everyone has one",
+      "30% feels natural for a mix of common folk and notable figures",
+      "Increase percentage for legendary characters, decrease for commoners"
+    ],
+    "usage": [
+      "python scripts/namegen.py full --nameset fantasy-epithets-example --count 10",
+      "# Expect roughly 3 out of 10 to have epithets"
+    ]
+  }
+}

--- a/references/nameset-guide.md
+++ b/references/nameset-guide.md
@@ -313,6 +313,15 @@ Add a percentage weight to control inclusion probability:
 
 Without a weight suffix, optional sections are included whenever their content resolves (100% when content exists).
 
+**Nested optionals** are supported for complex conditional naming:
+
+```json
+"format": "{firstName}[{title}[ {epithet}]] {lastName}"
+// If both exist: "Marcus Lord the Wise Chen"
+// If only title: "Marcus Lord Chen"
+// If neither: "Marcus Chen"
+```
+
 ### Random Generation
 
 Generate random numbers and character patterns for designations, serial numbers, and procedural names.

--- a/references/nameset-guide.md
+++ b/references/nameset-guide.md
@@ -163,13 +163,66 @@ Each entry in a category:
 
 ### Gender Weights
 
-Control the male/female distribution for the entire nameset:
+Control the gender distribution for the entire nameset:
 
 ```json
 "genderWeights": {"male": 75, "female": 25}
 ```
 
 Default is `{"male": 50, "female": 50}`. Can be overridden with `--gender male` or `--gender female`.
+
+#### Arbitrary Genders
+
+Gender weights can use **any gender identifiers**, not just male/female:
+
+```json
+// Fantasy creatures with three genders
+"genderWeights": {"male": 40, "female": 40, "neuter": 20}
+
+// Constructs/machines
+"genderWeights": {"military": 60, "civilian": 30, "prototype": 10}
+```
+
+Name entries can use matching gender tags:
+
+```json
+"firstName": [
+  {"name": "Krix", "gender": "neuter"},
+  {"name": "Unit-7", "gender": "military"},
+  {"name": "ARIA", "gender": "civilian"}
+]
+```
+
+When generating with `--gender neuter`, entries tagged as `"neuter"`, `"unisex"`, or untagged will be selected. This allows creative use of the gender system for any categorical filtering.
+
+#### Gender Cascade
+
+When a gender is selected (either via `--gender` flag or rolled from `genderWeights`), it applies to **ALL categories**, not just `firstName`.
+
+This enables gendered entries in any category:
+
+```json
+"nameCategories": {
+  "firstName": [
+    {"name": "Erik", "gender": "male"},
+    {"name": "Astrid", "gender": "female"}
+  ],
+  "title": [
+    {"name": "Lord", "gender": "male"},
+    {"name": "Lady", "gender": "female"},
+    {"name": "Ser", "gender": "unisex"}
+  ],
+  "suffix": [
+    {"name": "-son", "gender": "male"},
+    {"name": "-dottir", "gender": "female"}
+  ]
+},
+"format": "{title} {firstName} Storm{suffix}"
+// Male: "Lord Erik Stormson"
+// Female: "Lady Astrid Stormdottir"
+```
+
+Without gender tags, entries are selected regardless of the current gender.
 
 ### Frequency Weighting
 
@@ -218,6 +271,87 @@ Define any category name you need:
 },
 "format": "{firstName} {epithet}"
 // Output: "Keth the Swift"
+```
+
+### Per-Placeholder Gender Override
+
+Force a specific gender for individual placeholders using `{category:gender}` syntax:
+
+```json
+"format": "{firstName} {firstName:male}son"
+// If global gender is female: "Freya Bjornson" (female first, male patronym base)
+```
+
+This is essential for patronymic/matronymic naming systems where you need the parent's name to be a different gender than the child:
+
+```json
+// Dwarven patronymic: child's name + parent's name + suffix
+"format": "{firstName} {firstName:male}sson {firstName:female}sdottir"
+// Example: "Thorin Grimsson Hildisdottir" (child, father's name, mother's name)
+```
+
+The per-placeholder gender overrides the global `--gender` flag or rolled gender for that specific placeholder only.
+
+### Optional Sections
+
+Wrap content in square brackets to make it optional:
+
+```json
+"format": "{firstName}[ {epithet}] {lastName}"
+// If epithet exists: "Marcus the Brave Chen"
+// If epithet is missing/empty: "Marcus Chen"
+```
+
+Add a percentage weight to control inclusion probability:
+
+```json
+"format": "{firstName}[ {epithet}:30%] {lastName}"
+// 30% chance to include epithet even when available
+// Output: "Marcus Chen" (70% of the time)
+// Output: "Marcus the Brave Chen" (30% of the time)
+```
+
+Without a weight suffix, optional sections are included whenever their content resolves (100% when content exists).
+
+### Random Generation
+
+Generate random numbers and character patterns for designations, serial numbers, and procedural names.
+
+**Numeric ranges** - Random integer between min and max (inclusive):
+
+```json
+"format": "{prefix}-{random:1-999}"
+// Output: "XR-742"
+```
+
+**Character patterns** - Each pattern character generates a random value:
+
+| Pattern | Generates | Example |
+|---------|-----------|---------|
+| `A` | Uppercase letter (A-Z) | `AAA` -> `"KMZ"` |
+| `a` | Lowercase letter (a-z) | `aaa` -> `"qxm"` |
+| `0` | Digit (0-9) | `000` -> `"847"` |
+| `X` | Hex digit (0-9, A-F) | `XXXX` -> `"3A7F"` |
+| Other | Literal (preserved) | `A-0` -> `"K-7"` |
+
+Examples:
+
+```json
+// Robot designation
+"format": "{prefix}-{random:0000}"
+// Output: "MK-4728"
+
+// Ship registry
+"format": "{random:AAA}-{random:000}"
+// Output: "KMZ-847"
+
+// Hex identifier
+"format": "0x{random:XXXXXXXX}"
+// Output: "0x3A7F9C2E"
+
+// Mixed pattern
+"format": "{random:AA-000-aa}"
+// Output: "KM-742-qx"
 ```
 
 ### Multiple Formats
@@ -350,9 +484,19 @@ Names should be:
 
 See `references/examples/namesets/` for complete working examples:
 
-- **simple-western.json** - Basic first/last name structure
-- **aggregate-metropolitan.json** - Multi-source composition
+### Basic Examples
+
+- **simple-western.json** - Basic first/last name structure with gender tags and frequency weighting
+- **aggregate-example.json** - Multi-source composition from multiple namesets
 - **custom-categories.json** - Non-Western naming patterns (epithets, clans)
+
+### Advanced Feature Examples
+
+- **dwarven-patronymic.json** - Demonstrates per-placeholder gender override for patronymic/matronymic naming. Uses `{firstName:male}` and `{firstName:female}` to select parent names independent of child's gender.
+
+- **construct-designations.json** - Demonstrates random generation patterns for robots, constructs, and procedural designations. Shows `{random:0000}` numeric patterns and `{random:AAA}` letter patterns.
+
+- **fantasy-epithets.json** - Demonstrates optional sections with probability weights. Uses `[ {epithet}:30%]` syntax to occasionally include earned titles.
 
 ---
 

--- a/scripts/namegen.py
+++ b/scripts/namegen.py
@@ -48,22 +48,43 @@ def parse_format(format_str: str) -> List[Dict[str, Any]]:
     Supports optional sections with weight: [ {epithet}:30%]
     The :N% at the END of bracket content specifies inclusion probability.
     Default weight is 100 (always include if content resolves).
+    Nested optional sections are supported: [{title}[ {epithet}]]
     """
     tokens = []
-    pattern = r'\{(\w+)(?::([^}]+))?\}|\[([^\]]+)\]|([^\{\[]+)'
+    i = 0
 
-    for match in re.finditer(pattern, format_str):
-        if match.group(1):  # Placeholder {category} or {category:...}
-            category = match.group(1)
-            arg = match.group(2)  # Could be gender, range, or pattern
+    while i < len(format_str):
+        char = format_str[i]
+
+        if char == '{':
+            # Find matching closing brace
+            end = format_str.find('}', i)
+            if end == -1:
+                # No closing brace, treat as literal
+                tokens.append({"type": "literal", "value": char})
+                i += 1
+                continue
+
+            content = format_str[i+1:end]
+
+            # Check for category:arg pattern
+            if ':' in content:
+                category, arg = content.split(':', 1)
+            else:
+                category, arg = content, None
 
             if category == "random" and arg:
                 # Check if arg is a range (e.g., "1-99", "0-255")
                 range_match = re.match(r'^(\d+)-(\d+)$', arg)
                 if range_match:
+                    min_val = int(range_match.group(1))
+                    max_val = int(range_match.group(2))
+                    # Swap if reversed to prevent randint crash
+                    if min_val > max_val:
+                        min_val, max_val = max_val, min_val
                     tokens.append({
                         "type": "random",
-                        "range": [int(range_match.group(1)), int(range_match.group(2))]
+                        "range": [min_val, max_val]
                     })
                 else:
                     # It's a pattern (e.g., "AAA", "000", "XXX")
@@ -77,8 +98,28 @@ def parse_format(format_str: str) -> List[Dict[str, Any]]:
                     "value": category,
                     "gender": arg  # None if no gender specified
                 })
-        elif match.group(3):  # Optional section [text]
-            content = match.group(3)
+
+            i = end + 1
+
+        elif char == '[':
+            # Find matching closing bracket, accounting for nesting
+            depth = 1
+            start = i + 1
+            j = start
+            while j < len(format_str) and depth > 0:
+                if format_str[j] == '[':
+                    depth += 1
+                elif format_str[j] == ']':
+                    depth -= 1
+                j += 1
+
+            if depth != 0:
+                # Unmatched bracket, treat as literal
+                tokens.append({"type": "literal", "value": char})
+                i += 1
+                continue
+
+            content = format_str[start:j-1]
             weight = 100  # Default: always include
 
             # Check for weight suffix like :30% at end of content
@@ -94,8 +135,16 @@ def parse_format(format_str: str) -> List[Dict[str, Any]]:
                 "content": inner_tokens,
                 "weight": weight
             })
-        elif match.group(4):  # Literal text
-            tokens.append({"type": "literal", "value": match.group(4)})
+
+            i = j
+
+        else:
+            # Literal text - collect until next special character
+            end = i
+            while end < len(format_str) and format_str[end] not in '{[':
+                end += 1
+            tokens.append({"type": "literal", "value": format_str[i:end]})
+            i = end
 
     return tokens
 

--- a/scripts/namegen.py
+++ b/scripts/namegen.py
@@ -73,9 +73,11 @@ def parse_format(format_str: str) -> List[Dict[str, Any]]:
             else:
                 category, arg = content, None
 
-            if category == "random" and arg:
+            if category == "random":
+                # Handle {random}, {random:}, or {random:pattern}
+                effective_arg = arg or ""
                 # Check if arg is a range (e.g., "1-99", "0-255")
-                range_match = re.match(r'^(\d+)-(\d+)$', arg)
+                range_match = re.match(r'^(\d+)-(\d+)$', effective_arg)
                 if range_match:
                     min_val = int(range_match.group(1))
                     max_val = int(range_match.group(2))
@@ -87,10 +89,10 @@ def parse_format(format_str: str) -> List[Dict[str, Any]]:
                         "range": [min_val, max_val]
                     })
                 else:
-                    # It's a pattern (e.g., "AAA", "000", "XXX")
+                    # It's a pattern (e.g., "AAA", "000", "XXX", or empty)
                     tokens.append({
                         "type": "random",
-                        "pattern": arg
+                        "pattern": effective_arg
                     })
             else:
                 tokens.append({

--- a/scripts/namegen.py
+++ b/scripts/namegen.py
@@ -237,16 +237,17 @@ def generate_pattern(pattern: str) -> str:
     - X: random hex digit (0-9, A-F)
     - Anything else: literal (preserved as-is)
     """
+    char_map = {
+        'A': 'ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+        'a': 'abcdefghijklmnopqrstuvwxyz',
+        '0': '0123456789',
+        'X': '0123456789ABCDEF',
+    }
     result = []
     for char in pattern:
-        if char == 'A':
-            result.append(random.choice('ABCDEFGHIJKLMNOPQRSTUVWXYZ'))
-        elif char == 'a':
-            result.append(random.choice('abcdefghijklmnopqrstuvwxyz'))
-        elif char == '0':
-            result.append(random.choice('0123456789'))
-        elif char == 'X':
-            result.append(random.choice('0123456789ABCDEF'))
+        char_set = char_map.get(char)
+        if char_set:
+            result.append(random.choice(char_set))
         else:
             result.append(char)
     return ''.join(result)

--- a/scripts/namegen.py
+++ b/scripts/namegen.py
@@ -37,17 +37,65 @@ def discover_namesets(repo_root: Path):
 
 
 def parse_format(format_str: str) -> List[Dict[str, Any]]:
-    """Parse a format string into tokens."""
+    """Parse a format string into tokens.
+
+    Supports per-placeholder gender override: {category:gender}
+    Examples: {firstName:male}, {firstName:female}, {firstName}
+
+    Supports random pattern placeholders: {random:pattern}
+    Examples: {random:1-99} for range, {random:AAA} for pattern
+
+    Supports optional sections with weight: [ {epithet}:30%]
+    The :N% at the END of bracket content specifies inclusion probability.
+    Default weight is 100 (always include if content resolves).
+    """
     tokens = []
-    pattern = r'\{(\w+)\}|\[([^\]]+)\]|([^\{\[]+)'
+    pattern = r'\{(\w+)(?::([^}]+))?\}|\[([^\]]+)\]|([^\{\[]+)'
 
     for match in re.finditer(pattern, format_str):
-        if match.group(1):  # Placeholder {category}
-            tokens.append({"type": "placeholder", "value": match.group(1)})
-        elif match.group(2):  # Optional section [text]
-            tokens.append({"type": "optional", "value": match.group(2)})
-        elif match.group(3):  # Literal text
-            tokens.append({"type": "literal", "value": match.group(3)})
+        if match.group(1):  # Placeholder {category} or {category:...}
+            category = match.group(1)
+            arg = match.group(2)  # Could be gender, range, or pattern
+
+            if category == "random" and arg:
+                # Check if arg is a range (e.g., "1-99", "0-255")
+                range_match = re.match(r'^(\d+)-(\d+)$', arg)
+                if range_match:
+                    tokens.append({
+                        "type": "random",
+                        "range": [int(range_match.group(1)), int(range_match.group(2))]
+                    })
+                else:
+                    # It's a pattern (e.g., "AAA", "000", "XXX")
+                    tokens.append({
+                        "type": "random",
+                        "pattern": arg
+                    })
+            else:
+                tokens.append({
+                    "type": "placeholder",
+                    "value": category,
+                    "gender": arg  # None if no gender specified
+                })
+        elif match.group(3):  # Optional section [text]
+            content = match.group(3)
+            weight = 100  # Default: always include
+
+            # Check for weight suffix like :30% at end of content
+            weight_match = re.search(r':(\d+)%$', content)
+            if weight_match:
+                weight = int(weight_match.group(1))
+                content = content[:weight_match.start()]
+
+            # Parse the inner content as nested tokens
+            inner_tokens = parse_format(content)
+            tokens.append({
+                "type": "optional",
+                "content": inner_tokens,
+                "weight": weight
+            })
+        elif match.group(4):  # Literal text
+            tokens.append({"type": "literal", "value": match.group(4)})
 
     return tokens
 
@@ -92,7 +140,11 @@ def select_weighted_source(sources: List[Dict]) -> Dict:
 
 
 def select_gender(gender_weights: Dict[str, int]) -> str:
-    """Select gender using weights."""
+    """Select gender using weights.
+
+    Supports arbitrary gender strings. The keys in gender_weights can be any
+    gender identifier (e.g., "male", "female", "neuter", "construct", "machine").
+    """
     total = sum(gender_weights.values())
     rand = random.random() * total
 
@@ -104,18 +156,62 @@ def select_gender(gender_weights: Dict[str, int]) -> str:
     return list(gender_weights.keys())[-1]
 
 
-def filter_by_gender(entries: List[Dict], gender: str) -> List[Dict]:
-    """Filter name entries by gender. Includes unisex and unspecified names."""
+def filter_by_gender(entries: List[Dict], gender: str, category: Optional[str] = None) -> List[Dict]:
+    """Filter name entries by gender. Includes unisex and unspecified names.
+
+    Supports arbitrary gender strings (e.g., "male", "female", "neuter", "construct").
+    Matching rules:
+    - Exact match: entry gender equals requested gender
+    - Unisex: entries with gender="unisex" match any requested gender
+    - Untagged: entries with no gender (None) match any requested gender
+
+    If filtering results in empty list, falls back to unfiltered with warning.
+    """
     filtered = [e for e in entries if e.get("gender") in {gender, None, "unisex"}]
-    return filtered if filtered else entries
+    if filtered:
+        return filtered
+    else:
+        if category:
+            print(f"Warning: {category} has no entries for gender '{gender}', using unfiltered", file=sys.stderr)
+        return entries
+
+
+def generate_pattern(pattern: str) -> str:
+    """Generate a random string from a pattern.
+
+    Pattern characters:
+    - A: random uppercase letter (A-Z)
+    - a: random lowercase letter (a-z)
+    - 0: random digit (0-9)
+    - X: random hex digit (0-9, A-F)
+    - Anything else: literal (preserved as-is)
+    """
+    result = []
+    for char in pattern:
+        if char == 'A':
+            result.append(random.choice('ABCDEFGHIJKLMNOPQRSTUVWXYZ'))
+        elif char == 'a':
+            result.append(random.choice('abcdefghijklmnopqrstuvwxyz'))
+        elif char == '0':
+            result.append(random.choice('0123456789'))
+        elif char == 'X':
+            result.append(random.choice('0123456789ABCDEF'))
+        else:
+            result.append(char)
+    return ''.join(result)
+
+
+def generate_range(min_val: int, max_val: int) -> str:
+    """Generate a random integer in range and return as string."""
+    return str(random.randint(min_val, max_val))
 
 
 def generate_single_name(
     nameset: Dict,
-    format_str: str,
     gender: str
 ) -> str:
-    """Generate a single name from a source nameset."""
+    """Generate a single name from a source nameset using its own format and categories."""
+    format_str = nameset.get("format", "{firstName} {lastName}")
     categories = nameset.get("nameCategories", {})
 
     # Legacy support for old format
@@ -125,16 +221,8 @@ def generate_single_name(
             "lastName": nameset.get("lastNames", [])
         }
 
-    # Filter first names by gender
-    first_names = categories.get("firstName", [])
-    first_names = filter_by_gender(first_names, gender)
-
-    filtered_categories = {
-        "firstName": first_names,
-        "lastName": categories.get("lastName", [])
-    }
-
-    return build_name_from_format(format_str, filtered_categories)
+    # Pass gender to build_name_from_format for filtering at selection time
+    return build_name_from_format(format_str, categories, gender)
 
 
 def generate_from_aggregate(
@@ -148,7 +236,6 @@ def generate_from_aggregate(
     nameset = custom_namesets[nameset_id]
     sources = nameset.get("sources", [])
     gender_weights = nameset.get("genderWeights", {"male": 50, "female": 50})
-    format_str = nameset.get("format", "{firstName} {lastName}")
 
     results = []
     used = set()
@@ -176,8 +263,8 @@ def generate_from_aggregate(
             # Select gender
             selected_gender = gender if gender else select_gender(gender_weights)
 
-            # Generate from source
-            name = generate_single_name(source_nameset, format_str, selected_gender)
+            # Generate from source using source's own format and categories
+            name = generate_single_name(source_nameset, selected_gender)
 
             if name.lower() not in used:
                 if return_source:
@@ -235,15 +322,13 @@ def generate_from_nameset_with_groups(
             first_names = group_data.get("firstNames", [])
             last_names = group_data.get("lastNames", [])
 
-            # Filter by gender
-            first_names = filter_by_gender(first_names, selected_gender)
-
             categories = {
                 "firstName": first_names,
                 "lastName": last_names
             }
 
-            name = build_name_from_format(format_str, categories)
+            # Pass gender to build_name_from_format for filtering at selection time
+            name = build_name_from_format(format_str, categories, selected_gender)
             if name.lower() not in used or count > len(first_names):
                 if return_group:
                     results.append((name, selected_group))
@@ -279,18 +364,14 @@ def generate_from_nameset(nameset_id: str, count: int = 1, gender: Optional[str]
             "lastName": nameset.get("lastNames", [])
         }
 
-    # Filter first names by gender if specified
-    if gender and "firstName" in categories:
-        categories = categories.copy()
-        categories["firstName"] = filter_by_gender(categories["firstName"], gender)
-
     names = []
     used = set()
 
     for _ in range(count):
         attempts = 0
         while attempts < 100:
-            name = build_name_from_format(format_str, categories)
+            # Pass gender to build_name_from_format for filtering at selection time
+            name = build_name_from_format(format_str, categories, gender)
             if name.lower() not in used or count > len(categories.get("firstName", [])):
                 names.append(name)
                 used.add(name.lower())
@@ -298,14 +379,26 @@ def generate_from_nameset(nameset_id: str, count: int = 1, gender: Optional[str]
             attempts += 1
         else:
             # Ran out of attempts
-            names.append(build_name_from_format(format_str, categories))
+            names.append(build_name_from_format(format_str, categories, gender))
 
     return names
 
 
-def build_name_from_format(format_str: str, categories: Dict[str, List[Dict]]) -> str:
-    """Build a name from format string and name categories."""
-    tokens = parse_format(format_str)
+def build_name_from_tokens(
+    tokens: List[Dict[str, Any]],
+    categories: Dict[str, List[Dict]],
+    gender: Optional[str] = None,
+    in_optional: bool = False
+) -> str:
+    """Build a name from parsed tokens and name categories.
+
+    Gender filtering priority:
+    1. Per-placeholder override: {firstName:male} forces male filtering
+    2. Character gender: passed as parameter, applies to placeholders without override
+    3. No filtering: if neither is specified
+
+    When in_optional is True, missing categories are silently skipped.
+    """
     result = []
 
     for token in tokens:
@@ -314,15 +407,49 @@ def build_name_from_format(format_str: str, categories: Dict[str, List[Dict]]) -
         elif token["type"] == "placeholder":
             category = token["value"]
             if category in categories and categories[category]:
-                entry = select_weighted(categories[category])
+                entries = categories[category]
+                # Determine effective gender: per-placeholder override takes precedence
+                effective_gender = token.get("gender") or gender
+                # Apply gender filtering if gender specified and category has gendered entries
+                if effective_gender and any(e.get("gender") for e in entries):
+                    entries = filter_by_gender(entries, effective_gender, category)
+                entry = select_weighted(entries)
                 result.append(entry["name"])
-            else:
+            elif not in_optional:
+                # Warn only for top-level missing categories, not optional content
                 print(f"Warning: Format references undefined or empty category '{category}'", file=sys.stderr)
+        elif token["type"] == "random":
+            if "range" in token:
+                result.append(generate_range(token["range"][0], token["range"][1]))
+            elif "pattern" in token:
+                result.append(generate_pattern(token["pattern"]))
         elif token["type"] == "optional":
-            # For now, just parse the optional section like normal
-            result.append(build_name_from_format(token["value"], categories))
+            weight = token.get("weight", 100)
+            # Roll against weight percentage
+            if random.random() * 100 < weight:
+                inner_result = build_name_from_tokens(token["content"], categories, gender, in_optional=True)
+                if inner_result.strip():  # Only include if non-empty
+                    result.append(inner_result)
 
-    return "".join(result).strip()
+    return "".join(result)
+
+
+def build_name_from_format(
+    format_str: str,
+    categories: Dict[str, List[Dict]],
+    gender: Optional[str] = None
+) -> str:
+    """Build a name from format string and name categories.
+
+    Gender filtering priority:
+    1. Per-placeholder override: {firstName:male} forces male filtering
+    2. Character gender: passed as parameter, applies to placeholders without override
+    3. No filtering: if neither is specified
+    """
+    tokens = parse_format(format_str)
+    result = build_name_from_tokens(tokens, categories, gender)
+    # Clean up whitespace: collapse multiple spaces and strip
+    return " ".join(result.split())
 
 
 def safe_print(text: str):
@@ -391,11 +518,18 @@ def list_groups(nameset_id: str):
                 src_ns = custom_namesets[source_id]
                 categories = src_ns.get("nameCategories", {})
                 first_names = categories.get("firstName", [])
-                male_count = len([n for n in first_names if n.get("gender") == "male"])
-                female_count = len([n for n in first_names if n.get("gender") == "female"])
                 last_count = len(categories.get("lastName", []))
+                # Count names by gender (supports arbitrary genders)
+                gender_counts = {}
+                for n in first_names:
+                    g = n.get("gender") or "untagged"
+                    gender_counts[g] = gender_counts.get(g, 0) + 1
                 print(f"\n  {label} ({pct:.1f}%) -> {source_id}")
-                print(f"    Names: {male_count}M / {female_count}F / {last_count}L")
+                if gender_counts:
+                    counts_str = " / ".join(f"{c}{g[0].upper()}" for g, c in sorted(gender_counts.items()))
+                    print(f"    Names: {counts_str} / {last_count}L")
+                else:
+                    print(f"    Names: {len(first_names)} first / {last_count} last")
             else:
                 print(f"\n  {label} ({pct:.1f}%) -> {source_id} [NOT LOADED]")
 
@@ -414,12 +548,20 @@ def list_groups(nameset_id: str):
     for group_id, group in sorted(groups.items()):
         weight = group.get("weight", 1)
         pct = (weight / total_weight) * 100
-        male_count = len([n for n in group.get("firstNames", []) if n.get("gender") == "male"])
-        female_count = len([n for n in group.get("firstNames", []) if n.get("gender") == "female"])
+        first_names = group.get("firstNames", [])
         last_count = len(group.get("lastNames", []))
+        # Count names by gender (supports arbitrary genders)
+        gender_counts = {}
+        for n in first_names:
+            g = n.get("gender") or "untagged"
+            gender_counts[g] = gender_counts.get(g, 0) + 1
 
         print(f"\n  {group_id} ({pct:.0f}%)")
-        print(f"    First names: {male_count}M / {female_count}F")
+        if gender_counts:
+            counts_str = " / ".join(f"{c}{g[0].upper()}" for g, c in sorted(gender_counts.items()))
+            print(f"    First names: {counts_str}")
+        else:
+            print(f"    First names: {len(first_names)}")
         print(f"    Last names: {last_count}")
 
 


### PR DESCRIPTION
## Summary

- Fix aggregate namesets with custom categories - sources now use their own format/categories
- Gender cascades to ALL categories, not just firstName
- Per-placeholder gender override with `{category:gender}` syntax
- Arbitrary gender support (neuter, construct, any custom gender)
- Optional sections with `[ {epithet}]` and weighted `[ {epithet}:30%]`
- Random pattern generation: `{random:1-99}` (ranges) and `{random:AAA}` (patterns)

## New Format String Features

```
{firstName}              # uses character's gender
{firstName:male}         # forces male filtering
{firstName:female}       # forces female filtering
[ {epithet}]             # optional, include if category exists
[ {epithet}:30%]         # optional, 30% chance
{random:1-99}            # random number in range
{random:AAA}             # random pattern (A=letter, 0=digit, X=hex)
```

## Example Use Cases

**Dwarven patronymics:** `{firstName} {firstName:male}sson {firstName:female}sdottir`

**Construct designations:** `{prefix}-{random:0000}` → "Unit-7542"

**Optional epithets:** `{firstName}[ {epithet}:30%] {lastName}`

## Test plan

- [x] Basic name generation still works
- [x] `--gender` flag filters all gendered categories
- [x] Dwarven patronymic example generates correct suffixes
- [x] Construct example generates random patterns
- [x] Optional epithets appear ~30% of the time
- [x] Arbitrary gender filtering works

Closes #62, Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)