### PR TITLE
fix(delete): scan campaign/log.json, not nonexistent logs/ directory

### DIFF
--- a/scripts/characters.py
+++ b/scripts/characters.py
@@ -466,9 +466,23 @@ def find_character_references(char_id: str, search_root: Path) -> Dict[str, int]
                 print(f"Warning: Could not parse {path} for character references: {e}", file=sys.stderr)
         return count
 
-    log_refs = _count_refs(
-        search_root / "campaign" / "logs",
-        lambda item: item.get("characters", {}).keys()
+    def _count_log_refs(log_path: Path, extractor: Callable[[Dict], Iterable[str]]) -> int:
+        """Count entries in campaign/log.json that reference char_lower (case-insensitive)."""
+        if not log_path.exists():
+            return 0
+        try:
+            with open(log_path, encoding='utf-8-sig') as f:
+                entries = json.load(f)
+        except (OSError, json.JSONDecodeError) as e:
+            print(f"Warning: Could not parse {log_path} for character references: {e}", file=sys.stderr)
+            return 0
+        if not isinstance(entries, list):
+            return 0
+        return sum(1 for entry in entries if any(c.lower() == char_lower for c in extractor(entry)))
+
+    log_refs = _count_log_refs(
+        search_root / "campaign" / "log.json",
+        lambda entry: entry.get("characters", {}).keys() if isinstance(entry.get("characters"), dict) else []
     )
 
     mem_refs = _count_refs(

--- a/scripts/factions.py
+++ b/scripts/factions.py
@@ -721,9 +721,23 @@ def find_faction_references(faction_id: str, search_root: Path) -> Dict[str, int
                 print(f"Warning: Could not parse {path} for faction references: {e}", file=sys.stderr)
         return count
 
-    log_refs = _count_refs(
-        search_root / "campaign" / "logs",
-        lambda item: item.get("factions", {}).keys() if isinstance(item.get("factions"), dict) else []
+    def _count_log_refs(log_path: Path, extractor) -> int:
+        """Count entries in campaign/log.json that reference faction_lower (case-insensitive)."""
+        if not log_path.exists():
+            return 0
+        try:
+            with open(log_path, encoding='utf-8-sig') as f:
+                entries = json.load(f)
+        except (OSError, json.JSONDecodeError) as e:
+            print(f"Warning: Could not parse {log_path} for faction references: {e}", file=sys.stderr)
+            return 0
+        if not isinstance(entries, list):
+            return 0
+        return sum(1 for entry in entries if any(c.lower() == faction_lower for c in extractor(entry)))
+
+    log_refs = _count_log_refs(
+        search_root / "campaign" / "log.json",
+        lambda entry: entry.get("factions", {}).keys() if isinstance(entry.get("factions"), dict) else []
     )
 
     mem_refs = _count_refs(


### PR DESCRIPTION
## Summary

The character/faction delete safety check (introduced in the Wave 2 fixes,
commit `d9c57e1`) globs `campaign/logs/*.json` as a directory — but
`log.py` stores entries in a single file `campaign/log.json`. The directory
never exists, so `log_refs` is always 0 and the safety gate at
`characters.py:491-501` (and `factions.py:791-804`) silently allows deletion
of any character/faction that has zero memory refs, regardless of how many
log entries reference it.

Surfaced by ultrareview (bug_021) on PR #67.

## Fix

Replace the directory glob with a single-file load of `campaign/log.json`,
iterating the entry array and counting matches. Mirrors the existing
`_count_refs` closure pattern. Both files (characters.py, factions.py) use
the same fix.

## Manual repro (verified)

```
$ ls campaign/   # log.json exists, no logs/ dir
$ cat campaign/log.json
[{"id": "log-001", "summary": "Juno met the king", "characters": {"juno": "lead"}}]

# Before fix:
$ python scripts/characters.py delete juno
Deleted character: juno          # silently wiped, no warning

# After fix:
$ python scripts/characters.py delete juno
Warning: Character 'juno' is referenced in:
  - 1 log entries
Use --force to delete anyway.    # exits 1, deletion blocked
```

## Test plan
- [x] Manual repro (characters): warning fires, deletion blocked
- [x] Manual repro (factions): warning fires, deletion blocked
- [x] `--force` still bypasses correctly
- [ ] Manual review by user

## Notes

Test infrastructure for the rpg-tools repo lives on the in-flight
`feature/namegen-v2` branch (PR #67). Once that lands, a regression
test for this delete-safety path can be added on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)